### PR TITLE
Improve setup for Gitpod

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,13 +1,22 @@
 tasks:
   - init:
-      bundle install && 
+      bundle install &&
       yarn &&
-      bundle exec rake db:reset
+      bundle exec rake db:reset &&
+      touch /workspace/.build-done
+    command: bundle exec rails s -b 0.0.0.0
   - command:
-      bundle exec foreman start
+      while [ ! -f /workspace/.build-done ]; do sleep 1; done;
+      bundle exec hyperstack-hotloader -p 25222 -d app/hyperstack/
+    openMode: split-right
 ports:
   - port: 5000
+    onOpen: ignore
   - port: 3000
+    onOpen: open-preview
   - port: 9514
+    onOpen: ignore
   - port: 9515
+    onOpen: ignore
   - port: 25222
+    onOpen: ignore


### PR DESCRIPTION
This removes foreman, and uses Gitpod tasks instead:
 - `init` pulls and builds dependencies, db setup
 - two `commands`, in terminals next to each other, started after `init` finished successfully (using poor mans file lock):
    - `bundle exec rails s -b 0.0.0.0`
    - `bundle exec hyperstack-hotloader -p 25222 -d app/hyperstack/`
 - once puma started, open port 3000 in the preview

![image](https://user-images.githubusercontent.com/32448529/55790214-2b668000-5abc-11e9-8379-27a26e34ce9d.png)
